### PR TITLE
Update submodules and get zlib from user

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,20 +1,24 @@
-set (Boost_USE_STATIC_LIBS ON)
-set (Boost_USE_MULTITHREADED ON)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.11) # For IMPORTED_GLOBAL
+    find_package(ZLIB 1.2.11)
+    if(ZLIB_FOUND)
+        # To make an alias for an imported library, this needs to be set on.
+        set_target_properties(ZLIB::ZLIB PROPERTIES IMPORTED_GLOBAL ON)
+        add_library(zlib ALIAS ZLIB::ZLIB)
+    endif()
+endif()
 
-set (BOOST_COMPONENTS system 
-                      filesystem
-                      program_options)
+if(NOT ZLIB_FOUND)
+    add_subdirectory(zlib)
+    set(ZLIB_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/zlib")
+    set(ZLIB_LIBRARY "${CMAKE_CURRENT_SOURCE_DIR}/zlib/build/Debug/zlibstaticd.lib")
+endif()
 
-FIND_PACKAGE(Boost COMPONENTS ${BOOST_COMPONENTS} REQUIRED)
-
-set(ZLIB_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/zlib")
-set(ZLIB_LIBRARY "${CMAKE_CURRENT_SOURCE_DIR}/zlib/build/Debug/zlibstaticd.lib")
 set(LIBTOMCRYPT_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/libtomcrypt/build/include")
 set(LIBTOMCRYPT_LIBRARY "${CMAKE_CURRENT_SOURCE_DIR}/libtomcrypt/build/lib/tomcrypt.lib")
 set(LIBB64_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/libb64/include")
 set(LIBZRIF_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/libzrif/include")
 set(PSVPFSPARSER_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/psvpfsparser")
-add_subdirectory(zlib)
+
 add_subdirectory(libtomcrypt)
 add_subdirectory(libb64)
 add_subdirectory(libzrif)


### PR DESCRIPTION
This PR technically does two things.

* Removes Boost checking and grabbing since the only place that needs it here is actually in `psvpfsparser` now.
* Get `zlib` from the user side. As noted in the comments, if the user has a modern CMake version, we can actually compile against a user's own `zlib` by using the `IMPORTED_GLOBAL` property.