### PR TITLE
Fix CMake issue due to illegal target property set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,8 @@
-if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.11) # For IMPORTED_GLOBAL
-    find_package(ZLIB 1.2.11)
-    if(ZLIB_FOUND)
-        # To make an alias for an imported library, this needs to be set on.
-        set_target_properties(ZLIB::ZLIB PROPERTIES IMPORTED_GLOBAL ON)
-        add_library(zlib ALIAS ZLIB::ZLIB)
-    endif()
+cmake_minimum_required(VERSION 3.18)
+
+find_package(ZLIB 1.2.11)
+if(ZLIB_FOUND)
+    add_library(zlib ALIAS ZLIB::ZLIB)
 endif()
 
 if(NOT ZLIB_FOUND)


### PR DESCRIPTION
In recent CMake versions, attempting to promote imported targets that
are built in another directory to the global scope isn't allowed.
Since CMake 3.18, non-global targets can be aliased, rendering this
whole logic obsolete in newer CMake versions.